### PR TITLE
duplicate component removal

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,13 +1,10 @@
 <script lang="ts">
-import { defineComponent } from "vue";
-import TopNavigationBar from "../components/navigation/TopNavigationBar.vue";
+import { defineComponent } from 'vue'
 export default defineComponent({
-  components: { TopNavigationBar },
-});
+  components: {}
+})
 </script>
 
-<template>
-  <TopNavigationBar />
-</template>
+<template></template>
 
 <style></style>


### PR DESCRIPTION
1.  **TopNavigationBar.vue** import and component removed from **Home.vue** because it was duplicated 
#8 

![Home](https://user-images.githubusercontent.com/107875273/188971066-0c454189-5dc0-4f90-b4fb-ac12e2531dc1.png)
3. Now it's only on **app.vue**
